### PR TITLE
fix Two Sum bug

### DIFF
--- a/C++/chapLinearList.tex
+++ b/C++/chapLinearList.tex
@@ -455,7 +455,7 @@ public:
         }
         for (int i = 0; i < num.size(); i++) {
             const int gap = target - num[i];
-            if (mapping.find(gap) != mapping.end()) {
+            if (mapping.find(gap) != mapping.end() && mapping[gap] > i) {
                 result.push_back(i + 1);
                 result.push_back(mapping[gap] + 1);
                 break;


### PR DESCRIPTION
According to the question description, index1 must be less than index2.

The original solution failed to pass the below case.

Input:  [3,2,4], 6
Output: 1, 1
Expected:   2, 3
