### PR TITLE
Chap Divide and Conquer: fix overflow for pow(x, n)

### DIFF
--- a/C++/chapDivideAndConquer.tex
+++ b/C++/chapDivideAndConquer.tex
@@ -21,7 +21,7 @@ Implement pow(x, n).
 class Solution {
 public:
     double pow(double x, int n) {
-        if (n < 0) return 1.0 / power(x, -n);
+        if (n < 0) return 1.0 / (x * power(x, -(n+1)));
         else return power(x, n);
     }
 private:


### PR DESCRIPTION
Given n equals to -2147483648,  it will overflow if using power(x, -n) directly.
It's odd that the the previous version can be Accepted.
