### PR TITLE
Fix a typo in "Combination Sum"

### DIFF
--- a/C++/chapDFS.tex
+++ b/C++/chapDFS.tex
@@ -659,7 +659,7 @@ The same repeated number may be chosen from $C$ \emph{unlimited} number of times
 Note:
 \begindot
 \item All numbers (including target) will be positive integers.
-\item Elements in a combination ($a_1, a_2, ..., a_k$) must be in non-descending order. (ie, $a_1 > a_2 > ... > a_k$).
+\item Elements in a combination ($a_1, a_2, ..., a_k$) must be in non-descending order. (ie, $a_1 \leq a_2 \leq ... \leq a_k$).
 \item The solution set must not contain duplicate combinations.
 \myenddot
 


### PR DESCRIPTION
On the problem's website :

https://oj.leetcode.com/problems/combination-sum/

the description of the problem had changed.

As the Note says, elements are in non-descending order, the greater-than sign
may lead to misunderstanding, and Leetcode had changed it to less-and-equal-than sign.

so I updated the content in the source file.
