### PR TITLE
fix a bug in "Remove Duplicates from Sorted List"

### DIFF
--- a/C++/chapLinearList.tex
+++ b/C++/chapLinearList.tex
@@ -2217,7 +2217,7 @@ public:
     ListNode *deleteDuplicates(ListNode *head) {
         if (head == nullptr) return nullptr;
 
-        for (ListNode *prev = head, *cur = head->next; cur; cur = cur->next) {
+        for (ListNode *prev = head, *cur = head->next; cur; cur = prev->next) {
             if (prev->val == cur->val) {
                 prev->next = cur->next;
                 delete cur;


### PR DESCRIPTION
In the original code, if the expression 'prev->val == cur->val' returns true, then prev->next will be updated and the memory 'cur' points to will be released. So, the cur = cur->next in 'for' is in fact illegal. 

I fix this bug by just change cur = cur->next to cur=prev->next.